### PR TITLE
improve Transfer and Approval event definition

### DIFF
--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -21,8 +21,8 @@ contract Token {
     mapping(address => uint256) balances;
     mapping(address => mapping(address => uint256)) allowed;
 
-    event Transfer(address from, address to, uint256 value);
-    event Approval(address owner, address spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
 
     constructor(
         string memory _name,


### PR DESCRIPTION
It seems `indexed` syntax is missing. ERC-20 spec requires it.

- https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol#L75
- https://ethereum.org/en/developers/docs/standards/tokens/erc-20/
- https://ethereum.stackexchange.com/questions/120113/no-events-are-recorded-on-token-page/120115
